### PR TITLE
toss the data if we're over 2000 chars so we don't logjam

### DIFF
--- a/src/js/out_queue.js
+++ b/src/js/out_queue.js
@@ -304,9 +304,9 @@
         newRequest = newRequest.replace(queryUrlRe, function (match, base) {
           return  [base, '(filtered)'].join('');
         });
-        if (newRequest.length > 2000) {
-          newRequest = newRequest.replace(/ue_px=[^&]*/, ['ue_pr=', encodeURIComponent(json2.stringify({filtered: true, length: newRequest.length}))].join(''));
-        }
+      }
+      if (newRequest.length > 2000) {
+        newRequest = newRequest.replace(/ue_px=[^&]*/, ['ue_pr=', encodeURIComponent(json2.stringify({filtered: true, length: newRequest.length}))].join(''));
       }
       return newRequest;
     }


### PR DESCRIPTION
in localStorage.

Basically just promoted the 2000 char check out of the surrounding `if` statement. This way, any event that has over 2000 chars will just drop the data bit.  We'll should still get the url in most cases tho.